### PR TITLE
Normalize package ids using ToLowerInvariant before calling NuGet api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Normalize package ids using ToLowerInvariant before calling NuGet api
 
 ## [0.2.0] / 2023-11-15
 - Add .NET 8 support

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{SemVer}+{BranchName}.{ShortSha}'
-next-version: 0.2.0
+next-version: 0.2.1
 branches: {}
 ignore:
   sha: []


### PR DESCRIPTION
This fixes some packages returning 404 when checking for updates.