### PR TITLE
Implement Directory.Build.props support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Implement support for Directory.Build.props files
 
 ## [0.2.2] / 2023-11-22
 - Implement support for F# projects (.fsproj)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <!-- General -->
     <PropertyGroup>
+        <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <Features>strict</Features>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{SemVer}+{BranchName}.{ShortSha}'
-next-version: 0.2.2
+next-version: 0.2.3
 branches: {}
 ignore:
   sha: []

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -3,7 +3,6 @@
 // https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
 
 using System.Collections.Generic;
-using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.ProjectModel;
 using Nuke.Components;

--- a/examples/MajorVersionUpgrade/MajorVersionUpgrade.csproj
+++ b/examples/MajorVersionUpgrade/MajorVersionUpgrade.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/DotnetCheckUpdates/CliConstants.cs
+++ b/src/DotnetCheckUpdates/CliConstants.cs
@@ -8,6 +8,8 @@ internal static class CliConstants
 {
     public const string CliName = "dotnet-check-updates";
 
+    public const string DirectoryBuildPropsFileName = "Directory.Build.props";
+
     public const string SlnExtensionWithoutDot = "sln";
     public const string SlnExtensionWithDot = "." + SlnExtensionWithoutDot;
     public const string SlnPattern = "*" + SlnExtensionWithDot;

--- a/src/DotnetCheckUpdates/CliProgram.cs
+++ b/src/DotnetCheckUpdates/CliProgram.cs
@@ -175,7 +175,7 @@ static List<IRenderable?>? GetRenderableErrorMessage(Exception ex, bool convert 
 {
     if (ex is CommandAppException renderable && renderable.Pretty is not null)
     {
-        return new List<IRenderable?> { renderable.Pretty };
+        return [renderable.Pretty];
     }
 
     if (convert)

--- a/src/DotnetCheckUpdates/Core/ProjectModel/Import.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/Import.cs
@@ -1,0 +1,62 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+using System.Text.RegularExpressions;
+using DotnetCheckUpdates.Core.Utils;
+
+namespace DotnetCheckUpdates.Core.ProjectModel;
+
+internal partial record Import(string Project)
+{
+#if NET7_0_OR_GREATER
+    private static readonly Regex s_GetPathOfFileAboveRE = GeneratePathofFileAboveRegex();
+#else
+    private static readonly Regex s_GetPathOfFileAboveRE =
+        new(
+            """::GetPathOfFileAbove\(\s*['"]\s*([\$\(\)\w\./]+)['"]\s*,\s*['""]\s*([\$\(\)\w\./]+)\s*['""]\s*\)""",
+            RegexOptions.Compiled
+        );
+#endif
+
+    public string GetImportedProjectPath(IFileFinder fileFinder, string thisFileDirectory)
+    {
+        //
+        // Assume format
+        // $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))
+        // "::GetPathOfFileAbove\(['""]([\w\.]+)['""]\s*,\s*['""]([\$\(\)\w\./]+)['""]\)"gm
+        if (s_GetPathOfFileAboveRE.Match(Project) is Match match)
+        {
+            var fileName = match.Groups[1].Value;
+
+            static string EnsureTrailingSeparator(string input)
+            {
+                var span = input.AsSpan();
+
+                span = span.TrimEnd(Path.DirectorySeparatorChar)
+                    .TrimEnd(Path.AltDirectorySeparatorChar);
+
+                return span.ToString() + Path.DirectorySeparatorChar;
+            }
+
+            var startingDirectory = match
+                .Groups[2]
+                .Value.Replace(
+                    "$(MSBuildThisFileDirectory)",
+                    EnsureTrailingSeparator(thisFileDirectory)
+                );
+
+            return fileFinder.GetPathOfFileAbove(fileName, startingDirectory);
+        }
+
+        return Project;
+    }
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(
+        """::GetPathOfFileAbove\(\s*['"]\s*([\$\(\)\w\./]+)['"]\s*,\s*['""]\s*([\$\(\)\w\./]+)\s*['""]\s*\)""",
+        RegexOptions.Compiled
+    )]
+    private static partial Regex GeneratePathofFileAboveRegex();
+#endif
+}

--- a/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFile.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFile.cs
@@ -19,6 +19,16 @@ internal record ProjectFile(
 {
     public int PackageCount => PackageReferences.Length;
 
+    public string? Sdk { get; init; }
+
+    // TODO: This can be simplified once we drop support for older frameworks
+#pragma warning disable IDE0301 // Simplify collection initialization
+    public ImmutableArray<Import> Imports { get; init; } = ImmutableArray<Import>.Empty;
+#pragma warning restore IDE0301 // Simplify collection initialization
+
+    public bool IsDirectoryBuildProps =>
+        FilePath.EndsWith(CliConstants.DirectoryBuildPropsFileName);
+
     public XDocument Xml { get; internal set; } = new();
 
     private bool NeedsUpdate { get; set; }
@@ -105,14 +115,14 @@ internal record ProjectFile(
     {
         if (NeedsUpdate)
         {
-            Xml = GetUpdatedXm();
+            Xml = GetUpdatedXml();
             NeedsUpdate = false;
         }
 
         return Xml.ToString(SaveOptions.DisableFormatting);
     }
 
-    private XDocument GetUpdatedXm()
+    private XDocument GetUpdatedXml()
     {
         var newDocument = new XDocument(Xml);
 

--- a/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFileReader.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFileReader.cs
@@ -19,6 +19,6 @@ internal class ProjectFileReader
     public async Task<ProjectFile> ReadProjectFile(string filePath)
     {
         var content = await _fileSystem.File.ReadAllTextAsync(filePath, Encoding.UTF8);
-        return ProjectFileParser.ParseProjectFile(content, filePath);
+        return ProjectFileParser.ParseLessStrictProjectFile(content, filePath);
     }
 }

--- a/src/DotnetCheckUpdates/Core/Utils/FileFinder.cs
+++ b/src/DotnetCheckUpdates/Core/Utils/FileFinder.cs
@@ -17,6 +17,139 @@ internal class FileFinder : IFileFinder
         _fileSystem = fileSystem;
     }
 
+    public bool TryGetPathOfFile(string fileName, string cwd, out string filePath)
+    {
+        filePath = "";
+
+        // Absolute paths returned as is
+        if (_fileSystem.Path.IsPathRooted(fileName))
+        {
+            if (_fileSystem.File.Exists(fileName))
+            {
+                filePath = fileName;
+                return true;
+            }
+
+            return false;
+        }
+
+        fileName =
+            _fileSystem.Path.GetFileName(fileName)
+            ?? throw new InvalidOperationException("Must be have a filename");
+
+        var dir = _fileSystem.DirectoryInfo.New(GetFullDirectoryPath(cwd));
+
+        if (dir.Exists)
+        {
+            var file = dir.GetFiles(fileName, SearchOption.TopDirectoryOnly).FirstOrDefault();
+
+            if (file is not null && file.Exists)
+            {
+                filePath = file.FullName;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // https://learn.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2022#msbuild-getpathoffileabove
+    public string GetPathOfFileAbove(string fileName, string? startingDirectory = default)
+    {
+        // Absolute paths returned as is
+        if (_fileSystem.Path.IsPathRooted(fileName))
+        {
+            if (_fileSystem.File.Exists(fileName))
+            {
+                return fileName;
+            }
+
+            return "";
+        }
+
+        fileName =
+            _fileSystem.Path.GetFileName(fileName)
+            ?? throw new InvalidOperationException("Must be have a filename");
+
+        var cwd = _fileSystem.DirectoryInfo.New(GetFullDirectoryPath(startingDirectory ?? "./"));
+
+        while (cwd is not null)
+        {
+            if (cwd.Exists)
+            {
+                foreach (var file in cwd.GetFiles(fileName, SearchOption.TopDirectoryOnly))
+                {
+                    if (file.Exists)
+                    {
+                        return file.FullName;
+                    }
+                }
+            }
+
+            cwd = cwd.Parent;
+        }
+
+        return "";
+    }
+
+    private string GetFullDirectoryPath(string dir)
+    {
+        return _fileSystem.Path.GetFullPath(
+            _fileSystem.Path.GetDirectoryName(dir)
+                ?? throw new InvalidOperationException("Must have directory"),
+            _fileSystem.Directory.GetCurrentDirectory()
+        );
+    }
+
+    public IEnumerable<string> GetFilesFromDirectoryAndAbove(string baseDirectory, string fileName)
+    {
+        // Absolute paths returned as is
+        if (_fileSystem.Path.IsPathRooted(fileName))
+        {
+            yield return fileName;
+            yield break;
+        }
+
+        var actualFileName =
+            _fileSystem.Path.GetFileName(fileName)
+            ?? throw new InvalidOperationException("Must be have a filename");
+
+        baseDirectory = GetFullDirectoryPath(baseDirectory);
+
+        HashSet<string> directoriesToSearch = [baseDirectory];
+
+        foreach (var dir in directoriesToSearch)
+        {
+            foreach (var files in SearchForFileStartingFrom(dir))
+            {
+                yield return files;
+            }
+        }
+
+        IEnumerable<string> SearchForFileStartingFrom(string directory)
+        {
+            var cwd = _fileSystem.DirectoryInfo.New(directory);
+
+            while (cwd is not null)
+            {
+                if (cwd.Exists)
+                {
+                    foreach (
+                        var file in cwd.GetFiles(actualFileName, SearchOption.TopDirectoryOnly)
+                    )
+                    {
+                        if (file.Exists)
+                        {
+                            yield return file.FullName;
+                        }
+                    }
+                }
+
+                cwd = cwd.Parent;
+            }
+        }
+    }
+
     public async Task<IEnumerable<string>> GetMatchingPaths(
         string baseDirectory,
         IEnumerable<string> patterns

--- a/src/DotnetCheckUpdates/Core/Utils/IFileFinder.cs
+++ b/src/DotnetCheckUpdates/Core/Utils/IFileFinder.cs
@@ -6,6 +6,9 @@ namespace DotnetCheckUpdates.Core.Utils;
 
 internal interface IFileFinder
 {
+    bool TryGetPathOfFile(string fileName, string cwd, out string filePath);
+    string GetPathOfFileAbove(string fileName, string? startingDirectory = default);
+    IEnumerable<string> GetFilesFromDirectoryAndAbove(string baseDirectory, string fileName);
     Task<IEnumerable<string>> GetMatchingPaths(string baseDirectory, IEnumerable<string> patterns);
     Task<IEnumerable<string>> GetMatchingPaths(string baseDirectory, string pattern) =>
         GetMatchingPaths(baseDirectory, new[] { pattern });

--- a/src/DotnetCheckUpdates/DotnetCheckUpdates.csproj
+++ b/src/DotnetCheckUpdates/DotnetCheckUpdates.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandOutputTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandOutputTests.cs
@@ -2,12 +2,10 @@
 // Distributed under the MIT License.
 // https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
 
-using System.Text.Json;
 using DotnetCheckUpdates.Commands.CheckUpdate;
 using DotnetCheckUpdates.Core;
 using DotnetCheckUpdates.Core.Extensions;
 using DotnetCheckUpdates.Core.ProjectModel;
-using FluentAssertions.Execution;
 using Spectre.Console.Cli;
 using Spectre.Console.Testing;
 using static DotnetCheckUpdates.Tests.CheckUpdateCommandUtils;

--- a/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandTests.cs
@@ -24,7 +24,7 @@ public partial class CheckUpdateCommandTests
         // Arrange
         var cwd = RootedTestPath("some/path");
 
-        var fileSystem = SetupFileSystem(currentDirectory: cwd, fileContents: new() { });
+        var fileSystem = SetupFileSystem(currentDirectory: cwd, fileContents: []);
 
         var service = SetupMockNuGetService();
 
@@ -61,7 +61,7 @@ public partial class CheckUpdateCommandTests
         // Arrange
         var cwd = RootedTestPath("some/path");
 
-        var fileSystem = SetupFileSystem(currentDirectory: cwd, fileContents: new() { });
+        var fileSystem = SetupFileSystem(currentDirectory: cwd, fileContents: []);
 
         var service = SetupMockNuGetService();
 

--- a/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ImportTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ImportTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+namespace DotnetCheckUpdates.Tests.Core.ProjectModel;
+
+using DotnetCheckUpdates.Core.ProjectModel;
+using DotnetCheckUpdates.Core.Utils;
+using static DotnetCheckUpdates.Tests.TestUtils;
+
+public class ImportTests
+{
+    public const string FileName = CliConstants.DirectoryBuildPropsFileName;
+
+    public class GetImportedProjectPathTests
+    {
+        [Fact]
+        public void CanResolveImportedMsBuildPathOfFileAbove()
+        {
+            var testRoot = RootedTestPath();
+
+            var fileSystem = SetupFileSystem(
+                testRoot,
+                new()
+                {
+                    [testRoot.PathCombine($"root/{CliConstants.DirectoryBuildPropsFileName}")] = """
+                        <Project></Project>
+                        """,
+                }
+            );
+
+            var cwd = testRoot.PathCombine("root/nested");
+
+            var fileFinder = new FileFinder(fileSystem);
+
+            var import = new Import(
+                "$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+            );
+
+            var pathOfFileAbove = import.GetImportedProjectPath(fileFinder, cwd);
+
+            pathOfFileAbove
+                .Should()
+                .Be(testRoot.PathCombine($"root/{CliConstants.DirectoryBuildPropsFileName}"));
+        }
+
+        [Theory]
+        [InlineData("root", "$(MSBuildThisFileDirectory)../", "")]
+        [InlineData("root", "$(MSBuildThisFileDirectory)", "root")]
+        [InlineData("root", ".", "root")]
+        [InlineData("root/nested", "$(MSBuildThisFileDirectory)../", "root/")]
+        [InlineData("root/nested", "$(MSBuildThisFileDirectory)", "root/nested")]
+        [InlineData("root/nested", ".", "root/nested")]
+        [InlineData("root/nested/nested1", "$(MSBuildThisFileDirectory)", "root/nested")]
+        [InlineData("root/nested/nested1", ".", "root/nested")]
+        public void StartingDirectoryIsUsed(string start, string importPath, string expectedPath)
+        {
+            var testRoot = RootedTestPath();
+
+            var fileSystem = SetupFileSystem(
+                testRoot,
+                new()
+                {
+                    [testRoot.PathCombine($"root/{FileName}")] = """
+                        <Project></Project>
+                        """,
+                    [testRoot.PathCombine($"root/nested/{FileName}")] = """
+                        <Project></Project>
+                        """,
+                }
+            );
+
+            var cwd = testRoot.PathCombine(start);
+
+            fileSystem.Directory.SetCurrentDirectory(cwd);
+
+            var fileFinder = new FileFinder(fileSystem);
+
+            var import = new Import(
+                $"$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '{importPath}'))"
+            );
+
+            var pathOfFileAbove = import.GetImportedProjectPath(fileFinder, cwd);
+
+            if (expectedPath.Length == 0)
+            {
+                pathOfFileAbove.Should().BeEmpty();
+            }
+            else
+            {
+                pathOfFileAbove.Should().Be(testRoot.PathCombine($"{expectedPath}/{FileName}"));
+            }
+        }
+
+        [Fact]
+        public void ReturnsEmptyWhenPathOfFileAboveWasNotFound()
+        {
+            var testRoot = RootedTestPath();
+
+            var fileSystem = SetupFileSystem(testRoot, []);
+
+            var cwd = testRoot.PathCombine("root/nested");
+
+            var fileFinder = new FileFinder(fileSystem);
+
+            var import = new Import(
+                "$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+            );
+
+            var pathOfFileAbove = import.GetImportedProjectPath(fileFinder, cwd);
+
+            pathOfFileAbove.Should().BeEmpty();
+        }
+    }
+}

--- a/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ParseDirectoryBuildPropsTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ParseDirectoryBuildPropsTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+using DotnetCheckUpdates.Core.ProjectModel;
+
+namespace DotnetCheckUpdates.Tests.Core.ProjectModel;
+
+public class ParseDirectoryBuildPropsTests
+{
+    [Fact]
+    public void ParsesFileWithPackageReferencesWithoutTargetFramework()
+    {
+        const string xml = """
+<Project>
+    <!-- General -->
+    <PropertyGroup>
+        <LangVersion>12.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <Features>strict</Features>
+    </PropertyGroup>
+
+    <!-- Build -->
+    <PropertyGroup>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <WarnOnPackingNonPackableProject>true</WarnOnPackingNonPackableProject>
+    </PropertyGroup>
+
+    <!-- Packaging -->
+    <PropertyGroup Label="Packaging">
+        <!-- Enable packaging on a per-project basis. -->
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Example" Version="3.0.178" />
+    </ItemGroup>
+</Project>
+""";
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        using var scope = new AssertionScope();
+        file.TargetFrameworks.Should().BeEmpty();
+
+        file.PackageReferences.Should()
+            .SatisfyRespectively(it =>
+            {
+                it.Name.Should().Be("Example");
+                it.GetVersionString().Should().Be("3.0.178");
+            });
+    }
+}

--- a/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ProjectFileParserTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ProjectFileParserTests.cs
@@ -22,7 +22,7 @@ public class ProjectFileParserTests
 
         projectFile
             .TargetFrameworks.Should()
-            .ContainEquivalentOf("net5.0".ToNuGetFramework())
+            .ContainEquivalentOf(Frameworks.Default.ToNuGetFramework())
             .And.HaveCount(1);
 
         projectFile
@@ -67,7 +67,7 @@ public class ProjectFileParserTests
 
         projectFile
             .TargetFrameworks.Should()
-            .ContainEquivalentOf("net5.0".ToNuGetFramework())
+            .ContainEquivalentOf(Frameworks.Net5_0.ToNuGetFramework())
             .And.HaveCount(1);
 
         projectFile

--- a/tests/DotnetCheckUpdates.Tests/Core/Utils/ProjectDiscoveryTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/Utils/ProjectDiscoveryTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+using DotnetCheckUpdates.Core.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+using static DotnetCheckUpdates.Tests.TestUtils;
+
+namespace DotnetCheckUpdates.Tests.Core.Utils;
+
+public class ProjectDiscoveryTests
+{
+    public const string FileName = CliConstants.DirectoryBuildPropsFileName;
+
+    [Fact]
+    public async Task FindsDirectoryBuildPropsFileInDirectoryOfProjectWithDefaultOptions()
+    {
+        // Arrange
+        var testRoot = RootedTestPath();
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: testRoot.PathCombine("some/path"),
+            fileContents: new()
+            {
+                [testRoot.PathCombine("some/path/project.csproj")] = "test-content",
+                [testRoot.PathCombine($"some/path/{FileName}")] = "test-content",
+                [testRoot.PathCombine($"some/{FileName}")] = "not-found",
+                [testRoot.PathCombine($"{FileName}")] = "not-found",
+            }
+        );
+
+        var sut = new ProjectDiscovery(
+            NullLogger<ProjectDiscovery>.Instance,
+            new FileFinder(fileSystem),
+            new TestSolutionParser(fileSystem)
+        );
+
+        // Act
+
+        var result = await sut.DiscoverProjectsAndSolutions(
+            new() { Cwd = fileSystem.Directory.GetCurrentDirectory(), }
+        );
+
+        // Asssert
+        using var scope = new AssertionScope();
+
+        result.ProjectFiles.Should().HaveCount(2);
+        result
+            .ProjectFiles.Should()
+            .BeEquivalentTo(
+                [
+                    testRoot.PathCombine($"some/path/{FileName}"),
+                    testRoot.PathCombine("some/path/project.csproj"),
+                ]
+            );
+    }
+
+    [Fact]
+    public async Task FindDirectoryBuildPropsFilesWhenDiscoveringSolution()
+    {
+        // Arrange
+        var testRoot = RootedTestPath();
+
+        var solution = new MockSolution("solution/test.sln")
+        {
+            Projects =
+            {
+                new MockProject("src/project1/project1.csproj"),
+                new MockProject("src/project2/project2.csproj"),
+                new MockProject("tests/project3/project3.csproj"),
+            },
+        };
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: testRoot.PathCombine("solution"),
+            fileContents: new(solution.GetMockFiles(testRoot))
+            {
+                [testRoot.PathCombine($"{FileName}")] = "not-found",
+                [testRoot.PathCombine($"some/{FileName}")] = "not-found",
+                [testRoot.PathCombine($"solution/not-found/{FileName}")] = "not-found",
+
+                [testRoot.PathCombine($"solution/{FileName}")] = "found",
+                [testRoot.PathCombine($"solution/src/{FileName}")] = "found",
+                [testRoot.PathCombine($"solution/src/project2/{FileName}")] = "found",
+                [testRoot.PathCombine($"solution/tests/{FileName}")] = "found",
+            }
+        );
+
+        var sut = new ProjectDiscovery(
+            NullLogger<ProjectDiscovery>.Instance,
+            new FileFinder(fileSystem),
+            new TestSolutionParser(fileSystem)
+        );
+
+        // Act
+
+        var result = await sut.DiscoverProjectsAndSolutions(
+            new() { Cwd = fileSystem.Directory.GetCurrentDirectory(), }
+        );
+
+        // Asssert
+        using var scope = new AssertionScope();
+
+        result.ProjectFiles.Should().HaveCount(7);
+        result
+            .ProjectFiles.Should()
+            .BeEquivalentTo(
+                [
+                    testRoot.PathCombine($"solution/{FileName}"),
+                    testRoot.PathCombine($"solution/src/{FileName}"),
+                    testRoot.PathCombine("solution/src/project1/project1.csproj"),
+                    testRoot.PathCombine($"solution/src/project2/{FileName}"),
+                    testRoot.PathCombine("solution/src/project2/project2.csproj"),
+                    testRoot.PathCombine($"solution/tests/{FileName}"),
+                    testRoot.PathCombine("solution/tests/project3/project3.csproj"),
+                ]
+            );
+    }
+}

--- a/tests/DotnetCheckUpdates.Tests/DotnetCheckUpdates.Tests.csproj
+++ b/tests/DotnetCheckUpdates.Tests/DotnetCheckUpdates.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>

--- a/tests/DotnetCheckUpdates.Tests/Frameworks.cs
+++ b/tests/DotnetCheckUpdates.Tests/Frameworks.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+namespace DotnetCheckUpdates.Tests;
+
+internal static class Frameworks
+{
+    public const string Unspecified = "";
+
+    public const string Net5_0 = "net5.0";
+    public const string Net6_0 = "net6.0";
+    public const string Net7_0 = "net7.0";
+    public const string Net8_0 = "net8.0";
+    public const string NetStandard2_0 = "netstandard2.0";
+    public const string NetStandard2_1 = "netstandard2.1";
+
+    public const string Default = Net8_0;
+}

--- a/tests/DotnetCheckUpdates.Tests/GlobalUsings.cs
+++ b/tests/DotnetCheckUpdates.Tests/GlobalUsings.cs
@@ -4,5 +4,6 @@
 
 global using System.Collections.Immutable;
 global using FluentAssertions;
+global using FluentAssertions.Execution;
 global using NSubstitute;
 global using Xunit;

--- a/tests/DotnetCheckUpdates.Tests/MockFiles.cs
+++ b/tests/DotnetCheckUpdates.Tests/MockFiles.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2023 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+namespace DotnetCheckUpdates.Tests;
+
+internal class MockFiles : Dictionary<string, string>
+{
+    public MockFiles() { }
+
+    public MockFiles(IDictionary<string, string> dictionary)
+        : base(dictionary) { }
+
+    public MockFiles(IEnumerable<KeyValuePair<string, string>> collection)
+        : base(collection) { }
+
+    public MockFiles(IEqualityComparer<string>? comparer)
+        : base(comparer) { }
+
+    public MockFiles(int capacity)
+        : base(capacity) { }
+
+    public MockFiles(IDictionary<string, string> dictionary, IEqualityComparer<string>? comparer)
+        : base(dictionary, comparer) { }
+
+    public MockFiles(
+        IEnumerable<KeyValuePair<string, string>> collection,
+        IEqualityComparer<string>? comparer
+    )
+        : base(collection, comparer) { }
+
+    public MockFiles(int capacity, IEqualityComparer<string>? comparer)
+        : base(capacity, comparer) { }
+}

--- a/tests/DotnetCheckUpdates.Tests/MockProject.cs
+++ b/tests/DotnetCheckUpdates.Tests/MockProject.cs
@@ -4,9 +4,9 @@
 
 namespace DotnetCheckUpdates.Tests;
 
-internal record MockProject(string ProjectPath, string Framework = "net5.0")
+internal record MockProject(string ProjectPath, string Framework = Frameworks.Default)
 {
-    public List<(string id, string version)> Packages { get; init; } = new();
+    public List<(string id, string version)> Packages { get; init; } = [];
 
     public string ToXml()
     {

--- a/tests/DotnetCheckUpdates.Tests/MockSolution.cs
+++ b/tests/DotnetCheckUpdates.Tests/MockSolution.cs
@@ -6,7 +6,7 @@ namespace DotnetCheckUpdates.Tests;
 
 internal record MockSolution(string SolutionPath)
 {
-    public List<MockProject> Projects { get; init; } = new();
+    public List<MockProject> Projects { get; init; } = [];
 
     public string GetSolution()
     {
@@ -15,5 +15,19 @@ internal record MockSolution(string SolutionPath)
                 (Path.GetFileNameWithoutExtension(it.ProjectPath), it.ProjectPath)
             )
         );
+    }
+
+    public MockFiles GetMockFiles(string cwd)
+    {
+        var solutionFilePath = cwd.PathCombine(SolutionPath);
+
+        var solutionPath = Path.GetDirectoryName(solutionFilePath)!;
+
+        var projectsWithPaths = Projects.ToDictionary(
+            kvp => solutionPath.PathCombine(kvp.ProjectPath),
+            kvp => kvp.ToXml()
+        );
+
+        return new MockFiles(projectsWithPaths) { [solutionFilePath] = GetSolution() };
     }
 }

--- a/tests/DotnetCheckUpdates.Tests/MockUpgrade.cs
+++ b/tests/DotnetCheckUpdates.Tests/MockUpgrade.cs
@@ -6,12 +6,18 @@ namespace DotnetCheckUpdates.Tests;
 
 internal record MockUpgrade(string Name)
 {
-    public List<string> Versions { get; init; } = new();
+    public List<string> Versions { get; init; } = [];
 
-    public HashSet<string> SupportedFrameworks { get; init; } = new();
+    public HashSet<string> SupportedFrameworks { get; init; } = [];
 
     public static readonly HashSet<string> DefaultSupportedFrameworks =
-        new() { "net6.0", "net7.0", "netstandard2.0", "netstandard2.1" };
+    [
+        Frameworks.Net6_0,
+        Frameworks.Net7_0,
+        Frameworks.Net8_0,
+        Frameworks.NetStandard2_0,
+        Frameworks.NetStandard2_1
+    ];
 
     public void Deconstruct(
         out string name,

--- a/tests/DotnetCheckUpdates.Tests/ProjectFileUtils.cs
+++ b/tests/DotnetCheckUpdates.Tests/ProjectFileUtils.cs
@@ -11,12 +11,12 @@ internal static class ProjectFileUtils
 {
     public static string ProjectFileXml(
         IEnumerable<(string id, string version)> packages,
-        string framework = "net5.0"
+        string framework = Frameworks.Default
     ) => ProjectFileXml(packages.Select(it => PackageReference.From(it.id, it.version)), framework);
 
     public static string ProjectFileXml(
         IEnumerable<PackageReference> packages,
-        string framework = "net5.0"
+        string framework = Frameworks.Default
     ) =>
         $@"
 <Project Sdk=""Microsoft.NET.Sdk"">


### PR DESCRIPTION
Initial support for Directory.Build.props files. Packages defined in
Directory.Build.props can be upgraded just as regular projects.
Additionally TargetFrameworks defined in Directory.Build.props can
be used so projects no longer need to have those properties.