### PR TITLE
feat: parse and respect TargetFramework conditions on PackageReference items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -445,7 +445,8 @@ $RECYCLE.BIN/
 ## Visual Studio Code
 ##
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
+!.vscode/settings.json.template
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Update dependencies
+- feat: add TargetFramework condition support for package references
 
 ## [0.5.0] / 2025-11-24
 - Add support for .NET 10 and .NET 9

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{SemVer}+{BranchName}.{ShortSha}'
-next-version: 0.5.1
+next-version: 0.6.0
 branches: {}
 ignore:
   sha: []

--- a/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.Interactive.cs
+++ b/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.Interactive.cs
@@ -37,12 +37,14 @@ internal partial class CheckUpdateCommand
 
     private sealed class InteractiveTreePackage(
         string projectName,
+        string packageUpgradeKey,
         string packageName,
         VersionRange newVersion,
         string text
     ) : InteractiveTreeItem
     {
         public string ProjectName { get; } = projectName;
+        public string PackageUpgradeKey { get; } = packageUpgradeKey;
         public string PackageName { get; } = packageName;
         public VersionRange NewVersion { get; } = newVersion;
         public override string Text { get; } = text;
@@ -75,7 +77,10 @@ internal partial class CheckUpdateCommand
 
             foreach (var pkg in project.PackageReferences)
             {
-                longestPackageNameLength = Math.Max(longestPackageNameLength, pkg.Name.Length);
+                longestPackageNameLength = Math.Max(
+                    longestPackageNameLength,
+                    pkg.DisplayName.Length
+                );
                 longestVersionLength = Math.Max(
                     longestVersionLength,
                     pkg.GetVersionString().Length
@@ -151,8 +156,8 @@ internal partial class CheckUpdateCommand
                 InteractiveTreePackage FormatUpgrade(PackageUpgrade it)
                 {
                     sb.Clear();
-                    var nameLengthToPad = longestPackageNameLength - it.Name.Length;
-                    sb.Append(it.Name);
+                    var nameLengthToPad = longestPackageNameLength - it.DisplayName.Length;
+                    sb.Append(it.DisplayName);
                     sb.Append(' ', nameLengthToPad + 1);
 
                     var originalVersionString = it.From.VersionString();
@@ -162,7 +167,13 @@ internal partial class CheckUpdateCommand
                     sb.Append(" → ");
                     sb.Append(CheckUpdateCommandHelpers.GetUpgradedVersionString(it.From, it.To));
 
-                    return new(project.FilePath, it.Name, it.To, sb.ToString());
+                    return new(
+                        project.FilePath,
+                        it.UpgradeKey,
+                        it.PackageName,
+                        it.To,
+                        sb.ToString()
+                    );
                 }
             }
         }
@@ -233,9 +244,9 @@ internal partial class CheckUpdateCommand
 
             foreach (var choice in allProjectChoices)
             {
-                if (packages.TryGetValue(choice.PackageName, out var version))
+                if (packages.TryGetValue(choice.PackageUpgradeKey, out var version))
                 {
-                    selectedUpgrades[choice.PackageName] = version;
+                    selectedUpgrades[choice.PackageUpgradeKey] = version;
                 }
             }
 

--- a/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.NonInteractive.cs
+++ b/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.NonInteractive.cs
@@ -81,7 +81,10 @@ internal partial class CheckUpdateCommand
 
             foreach (var pkg in project.PackageReferences)
             {
-                longestPackageNameLength = Math.Max(longestPackageNameLength, pkg.Name.Length);
+                longestPackageNameLength = Math.Max(
+                    longestPackageNameLength,
+                    pkg.DisplayName.Length
+                );
                 longestVersionLength = Math.Max(
                     longestVersionLength,
                     pkg.GetVersionString().Length

--- a/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.RenderSolutionUpgrades.cs
+++ b/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommand.RenderSolutionUpgrades.cs
@@ -39,7 +39,10 @@ internal partial class CheckUpdateCommand
         {
             foreach (var pkg in project.PackageReferences)
             {
-                longestPackageNameLength = Math.Max(longestPackageNameLength, pkg.Name.Length);
+                longestPackageNameLength = Math.Max(
+                    longestPackageNameLength,
+                    pkg.DisplayName.Length
+                );
                 longestVersionLength = Math.Max(
                     longestVersionLength,
                     pkg.GetVersionString().Length

--- a/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommandHelpers.cs
+++ b/src/DotnetCheckUpdates/Commands/CheckUpdate/CheckUpdateCommandHelpers.cs
@@ -14,7 +14,13 @@ using Spectre.Console.Rendering;
 
 namespace DotnetCheckUpdates.Commands.CheckUpdate;
 
-internal record PackageUpgrade(string Name, VersionRange From, VersionRange To);
+internal record PackageUpgrade(
+    string UpgradeKey,
+    string PackageName,
+    string DisplayName,
+    VersionRange From,
+    VersionRange To
+);
 
 internal static partial class CheckUpdateCommandHelpers
 {
@@ -123,11 +129,11 @@ internal static partial class CheckUpdateCommandHelpers
             {
                 var results = await Task.WhenAll(chunk.Select(BoundGetBestPackageVersion));
 
-                foreach (var upgrade in results)
+                foreach (var result in results)
                 {
-                    if (upgrade is not null)
+                    if (result.Upgrade is not null)
                     {
-                        pkgs[upgrade.Id] = upgrade.Version;
+                        pkgs[result.Package.UpgradeKey] = result.Upgrade.Version;
                     }
                 }
             }
@@ -136,21 +142,32 @@ internal static partial class CheckUpdateCommandHelpers
         {
             foreach (var pkgRef in project.PackageReferences)
             {
-                var upgrade = await BoundGetBestPackageVersion(pkgRef);
+                var result = await BoundGetBestPackageVersion(pkgRef);
 
-                if (upgrade is not null)
+                if (result.Upgrade is not null)
                 {
-                    pkgs[upgrade.Id] = upgrade.Version;
+                    pkgs[result.Package.UpgradeKey] = result.Upgrade.Version;
                 }
             }
         }
 
         return (project, pkgs);
 
-        async Task<PackageVersionUpgrade?> BoundGetBestPackageVersion(PackageReference pkgRef)
+        async Task<(
+            PackageReference Package,
+            PackageVersionUpgrade? Upgrade
+        )> BoundGetBestPackageVersion(PackageReference pkgRef)
         {
+            var applicableFrameworks = pkgRef.GetApplicableFrameworks(project.TargetFrameworks);
+
+            if (applicableFrameworks.IsEmpty)
+            {
+                progress?.Increment(1);
+                return (pkgRef, null);
+            }
+
             var upgrade = await packageService.GetPackageUpgrade(
-                project.TargetFrameworks,
+                applicableFrameworks,
                 pkgRef,
                 target,
                 cancellationToken
@@ -158,7 +175,7 @@ internal static partial class CheckUpdateCommandHelpers
 
             progress?.Increment(1);
 
-            return upgrade;
+            return (pkgRef, upgrade);
         }
     }
 
@@ -172,12 +189,16 @@ internal static partial class CheckUpdateCommandHelpers
         foreach (var pkgRef in project.PackageReferences)
         {
             if (
-                upgrades.TryGetValue(pkgRef.Name, out var version)
-                && !pkgRef.Version.Equals(version)
+                (
+                    upgrades.TryGetValue(pkgRef.UpgradeKey, out var version)
+                    || upgrades.TryGetValue(pkgRef.Name, out version)
+                ) && !pkgRef.Version.Equals(version)
             )
             {
                 builder ??= ImmutableArray.CreateBuilder<PackageUpgrade>();
-                builder.Add(new(pkgRef.Name, pkgRef.Version, version));
+                builder.Add(
+                    new(pkgRef.UpgradeKey, pkgRef.Name, pkgRef.DisplayName, pkgRef.Version, version)
+                );
             }
         }
 
@@ -194,20 +215,26 @@ internal static partial class CheckUpdateCommandHelpers
 
         foreach (
             var originalPackage in original.PackageReferences.OrderBy(
-                it => it.Name,
+                it => it.DisplayName,
                 StringComparer.Ordinal
             )
         )
         {
             if (
-                updated.FindByNameWithIndex(originalPackage.Name)
+                updated.FindByIdentityWithIndex(originalPackage)
                     is (_, PackageReference updatedPackage)
                 && !originalPackage.Version.Equals(updatedPackage.Version)
             )
             {
                 didUpdate = true;
                 upgrades.Add(
-                    new(originalPackage.Name, originalPackage.Version, updatedPackage.Version)
+                    new(
+                        originalPackage.UpgradeKey,
+                        originalPackage.Name,
+                        originalPackage.DisplayName,
+                        originalPackage.Version,
+                        updatedPackage.Version
+                    )
                 );
             }
         }
@@ -234,12 +261,12 @@ internal static partial class CheckUpdateCommandHelpers
 
         var versionSpaces = new string(' ', longestVersion);
 
-        foreach (var originalPackage in original.PackageReferences.OrderBy(it => it.Name))
+        foreach (var originalPackage in original.PackageReferences.OrderBy(it => it.DisplayName))
         {
-            var nameLengthToPad = longestPackageName - originalPackage.Name.Length;
+            var nameLengthToPad = longestPackageName - originalPackage.DisplayName.Length;
 
             var paddedPackageName = new Padder(
-                new Text(originalPackage.Name),
+                new Text(originalPackage.DisplayName),
                 new(0, 0, nameLengthToPad, 0)
             );
 
@@ -249,7 +276,7 @@ internal static partial class CheckUpdateCommandHelpers
             var originalVersion = new Markup(originalVersionString.EscapeMarkup());
 
             if (
-                updated.FindByNameWithIndex(originalPackage.Name)
+                updated.FindByIdentityWithIndex(originalPackage)
                     is (_, PackageReference updatedPackage)
                 && !originalPackage.Version.Equals(updatedPackage.Version)
             )

--- a/src/DotnetCheckUpdates/Core/ProjectModel/PackageReference.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/PackageReference.cs
@@ -3,25 +3,80 @@
 // https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
 
 using DotnetCheckUpdates.Core.Extensions;
+using NuGet.Frameworks;
 using NuGet.Versioning;
 
 namespace DotnetCheckUpdates.Core.ProjectModel;
 
 internal record PackageReference(string Name, VersionRange Version) : IPackageReference
 {
+    public int ReferenceId { get; init; } = -1;
+
+    public ImmutableArray<TargetFrameworkCondition> TargetFrameworkConditions { get; init; } =
+        ImmutableArray<TargetFrameworkCondition>.Empty;
+
     internal VersionRange? OriginalRange { get; private set; }
 
     protected PackageReference(PackageReference original)
     {
         Name = original.Name;
         Version = original.Version;
+        ReferenceId = original.ReferenceId;
+        TargetFrameworkConditions = original.TargetFrameworkConditions;
         OriginalRange = original.OriginalRange ?? original.Version;
     }
+
+    public string UpgradeKey => ReferenceId >= 0 ? $"{ReferenceId}:{Name}" : Name;
+
+    public bool HasTargetFrameworkConditions => !TargetFrameworkConditions.IsDefaultOrEmpty;
+
+    public string DisplayName =>
+        !HasTargetFrameworkConditions
+            ? Name
+            : $"{Name} ({string.Join(" Or ", GetTargetFrameworkConditionGroups().Select(group => string.Join(" And ", group.Select(it => it.ToDisplayString()))))})";
 
     public bool HasVersion => !Version.Equals(VersionRange.None);
 
     public bool HasName(string name) =>
         string.Equals(Name, name, StringComparison.OrdinalIgnoreCase);
+
+    public bool HasReferenceId(int referenceId) => ReferenceId == referenceId;
+
+    public ImmutableArray<NuGetFramework> GetApplicableFrameworks(
+        IEnumerable<NuGetFramework> targetFrameworks
+    )
+    {
+        var frameworks = targetFrameworks.ToImmutableArray();
+
+        if (!HasTargetFrameworkConditions)
+        {
+            return frameworks;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<NuGetFramework>(frameworks.Length);
+        var groups = GetTargetFrameworkConditionGroups();
+
+        foreach (var framework in frameworks)
+        {
+            var frameworkName = framework.GetShortFolderName();
+
+            if (groups.Any(group => group.All(it => it.IsMatch(frameworkName))))
+            {
+                builder.Add(framework);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private ImmutableArray<
+        ImmutableArray<TargetFrameworkCondition>
+    > GetTargetFrameworkConditionGroups() =>
+        TargetFrameworkConditions
+            .GroupBy(it => it.GroupId)
+            .OrderBy(it => it.Key)
+            .Select(it => it.ToImmutableArray())
+            .ToImmutableArray();
 
     public static PackageReference From(string name, string version) =>
         new(name, version.ToVersionRange());

--- a/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFile.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFile.cs
@@ -59,7 +59,13 @@ internal record ProjectFile(
         var index = 0;
         foreach (var pkgRef in PackageReferences)
         {
-            if (pkgRef.HasVersion && packages.TryGetValue(pkgRef.Name, out var version))
+            if (
+                pkgRef.HasVersion
+                && (
+                    packages.TryGetValue(pkgRef.UpgradeKey, out var version)
+                    || packages.TryGetValue(pkgRef.Name, out version)
+                )
+            )
             {
                 if (builder is null)
                 {
@@ -102,6 +108,23 @@ internal record ProjectFile(
             : (-1, null);
 
     public int FindIndexByName(string name) => FindIndex(pkg => pkg.HasName(name));
+
+    public (int index, PackageReference? reference) FindByReferenceIdWithIndex(int referenceId) =>
+        FindIndex(pkg => pkg.HasReferenceId(referenceId)) is var index && index > -1
+            ? (index, PackageReferences[index])
+            : (-1, null);
+
+    public (int index, PackageReference? reference) FindByIdentityWithIndex(
+        PackageReference reference
+    )
+    {
+        if (reference.ReferenceId >= 0)
+        {
+            return FindByReferenceIdWithIndex(reference.ReferenceId);
+        }
+
+        return FindByNameWithIndex(reference.Name);
+    }
 
     public int FindIndex(Predicate<PackageReference> predicate) =>
         PackageReferences.FindIndex(predicate);
@@ -166,11 +189,17 @@ internal record ProjectFile(
 
         var references = newDocument.GetPackageReferenceElements().ToImmutableArray();
 
-        foreach (var element in references)
+        var hasReferenceIds = PackageReferences.Any(it => it.ReferenceId >= 0);
+
+        foreach (
+            var (element, elementIndex) in references.Select((element, index) => (element, index))
+        )
         {
-            var foundRef = PackageReferences.Find(item =>
-                item.HasName((string?)element.Attribute("Include") ?? "")
-            );
+            var foundRef = hasReferenceIds
+                ? PackageReferences.Find(item => item.HasReferenceId(elementIndex))
+                : PackageReferences.Find(item =>
+                    item.HasName((string?)element.Attribute("Include") ?? "")
+                );
 
             // Skip filtered packages
             if (foundRef is null)

--- a/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFileParser.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/ProjectFileParser.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT License.
 // https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
 
+using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using CommunityToolkit.Diagnostics;
@@ -38,8 +39,25 @@ internal static class Errors
 }
 #pragma warning restore S125 // Sections of code should not be commented out
 
-internal static class ProjectFileParser
+internal static partial class ProjectFileParser
 {
+    [GeneratedRegex(
+        "'\\s*\\$\\(\\s*TargetFramework\\s*\\)\\s*'\\s*(==|!=)\\s*'\\s*([^']+?)\\s*'",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 100
+    )]
+    private static partial Regex TargetFrameworkCondition();
+
+    [GeneratedRegex(
+        "\\bOr\\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 100
+    )]
+    private static partial Regex TargetFrameworkConditionOr();
+
+    private static readonly Regex s_targetFrameworkConditionRegex = TargetFrameworkCondition();
+    private static readonly Regex s_targetFrameworkConditionOrRegex = TargetFrameworkConditionOr();
+
     // https://learn.microsoft.com/en-us/dotnet/core/project-sdk/overview#available-sdks
     private static readonly HashSet<string> s_supportedSdks =
     [
@@ -197,14 +215,148 @@ internal static class ProjectFileParser
         this IEnumerable<XElement> elements
     ) =>
         elements
-            .Select(item =>
-                (
-                    include: (string?)item.Attribute("Include"),
-                    version: (string?)item.Attribute("Version")
-                )
+            .Select(
+                (item, index) =>
+                    (
+                        index,
+                        include: (string?)item.Attribute("Include"),
+                        version: (string?)item.Attribute("Version"),
+                        itemConditionGroups: ParseTargetFrameworkConditionGroups(
+                            (string?)item.Attribute("Condition")
+                        ),
+                        itemGroupConditionGroups: ParseTargetFrameworkConditionGroups(
+                            (string?)item.Parent?.Attribute("Condition")
+                        )
+                    )
             )
             .Where(item => !string.IsNullOrWhiteSpace(item.include))
-            .Select(item => new PackageReference(item.include!, item.version.ToVersionRange()));
+            .Select(item => new PackageReference(item.include!, item.version.ToVersionRange())
+            {
+                ReferenceId = item.index,
+                TargetFrameworkConditions = BuildConditions(
+                    item.itemGroupConditionGroups,
+                    item.itemConditionGroups
+                ),
+            });
+
+    private static ImmutableArray<
+        ImmutableArray<TargetFrameworkCondition>
+    > ParseTargetFrameworkConditionGroups(string? condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition))
+        {
+            return [];
+        }
+
+        var segments = s_targetFrameworkConditionOrRegex.Split(condition);
+        var groupBuilder = ImmutableArray.CreateBuilder<ImmutableArray<TargetFrameworkCondition>>();
+
+        for (var groupIndex = 0; groupIndex < segments.Length; groupIndex++)
+        {
+            var matches = s_targetFrameworkConditionRegex.Matches(segments[groupIndex]);
+
+            if (matches.Count == 0)
+            {
+                continue;
+            }
+
+            var conditionBuilder = ImmutableArray.CreateBuilder<TargetFrameworkCondition>(
+                matches.Count
+            );
+
+            foreach (Match match in matches)
+            {
+                var op = match.Groups[1].Value;
+                var framework = match.Groups[2].Value.Trim();
+
+                conditionBuilder.Add(
+                    new(
+                        op == "=="
+                            ? TargetFrameworkConditionOperator.Equals
+                            : TargetFrameworkConditionOperator.NotEquals,
+                        framework,
+                        match.Value,
+                        groupBuilder.Count
+                    )
+                );
+            }
+
+            groupBuilder.Add(conditionBuilder.ToImmutable());
+        }
+
+        return groupBuilder.ToImmutable();
+    }
+
+    private static ImmutableArray<TargetFrameworkCondition> BuildConditions(
+        ImmutableArray<ImmutableArray<TargetFrameworkCondition>> itemGroupConditionGroups,
+        ImmutableArray<ImmutableArray<TargetFrameworkCondition>> itemConditionGroups
+    )
+    {
+        if (itemGroupConditionGroups.IsDefaultOrEmpty && itemConditionGroups.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        if (itemGroupConditionGroups.IsDefaultOrEmpty)
+        {
+            return FlattenConditionGroups(itemConditionGroups);
+        }
+
+        if (itemConditionGroups.IsDefaultOrEmpty)
+        {
+            return FlattenConditionGroups(itemGroupConditionGroups);
+        }
+
+        var totalConditions =
+            itemGroupConditionGroups.Sum(it => it.Length) * itemConditionGroups.Length
+            + itemConditionGroups.Sum(it => it.Length) * itemGroupConditionGroups.Length;
+        var builder = ImmutableArray.CreateBuilder<TargetFrameworkCondition>(totalConditions);
+        var groupId = 0;
+
+        foreach (var itemGroupConditions in itemGroupConditionGroups)
+        {
+            foreach (var itemConditions in itemConditionGroups)
+            {
+                foreach (var condition in itemGroupConditions)
+                {
+                    builder.Add(condition with { GroupId = groupId });
+                }
+
+                foreach (var condition in itemConditions)
+                {
+                    builder.Add(condition with { GroupId = groupId });
+                }
+
+                groupId++;
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<TargetFrameworkCondition> FlattenConditionGroups(
+        ImmutableArray<ImmutableArray<TargetFrameworkCondition>> groups
+    )
+    {
+        if (groups.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        var builder = ImmutableArray.CreateBuilder<TargetFrameworkCondition>(
+            groups.Sum(it => it.Length)
+        );
+
+        for (var groupId = 0; groupId < groups.Length; groupId++)
+        {
+            foreach (var condition in groups[groupId])
+            {
+                builder.Add(condition with { GroupId = groupId });
+            }
+        }
+
+        return builder.ToImmutable();
+    }
 
     public static ProjectFile ParseProjectFile(string xmlContent, string filePath)
     {

--- a/src/DotnetCheckUpdates/Core/ProjectModel/TargetFrameworkCondition.cs
+++ b/src/DotnetCheckUpdates/Core/ProjectModel/TargetFrameworkCondition.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2023-2026 Ville Penttinen
+// Distributed under the MIT License.
+// https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
+
+namespace DotnetCheckUpdates.Core.ProjectModel;
+
+internal enum TargetFrameworkConditionOperator
+{
+    Equals,
+    NotEquals,
+}
+
+internal sealed record TargetFrameworkCondition(
+    TargetFrameworkConditionOperator Operator,
+    string TargetFramework,
+    string RawCondition,
+    int GroupId = 0
+)
+{
+    public bool IsMatch(string targetFramework) =>
+        Operator switch
+        {
+            TargetFrameworkConditionOperator.Equals => string.Equals(
+                TargetFramework,
+                targetFramework,
+                StringComparison.OrdinalIgnoreCase
+            ),
+            TargetFrameworkConditionOperator.NotEquals => !string.Equals(
+                TargetFramework,
+                targetFramework,
+                StringComparison.OrdinalIgnoreCase
+            ),
+            _ => false,
+        };
+
+    public string ToDisplayString()
+    {
+        return Operator == TargetFrameworkConditionOperator.Equals
+            ? TargetFramework
+            : $"!= {TargetFramework}";
+    }
+}

--- a/tests/DotnetCheckUpdates.Tests/CheckUpdateCommandUtils.cs
+++ b/tests/DotnetCheckUpdates.Tests/CheckUpdateCommandUtils.cs
@@ -184,7 +184,13 @@ internal static class CheckUpdateCommandUtils
 
         using (new AssertionScope())
         {
-            project.PackageReferences.Should().BeEquivalentTo(packageVersions);
+            project.PackageReferences.Should().HaveCount(packageVersions.Length);
+
+            foreach (var (actual, expected) in project.PackageReferences.Zip(packageVersions))
+            {
+                actual.Name.Should().Be(expected.Name);
+                actual.GetVersionString().Should().Be(expected.GetVersionString());
+            }
 
             project.ProjectFileToXml().Should().Be(ProjectFileXml(packages, framework));
         }

--- a/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandInteractiveOutputTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandInteractiveOutputTests.cs
@@ -3,14 +3,113 @@
 // https://github.com/vipentti/dotnet-check-updates/blob/main/LICENSE.md
 
 using DotnetCheckUpdates.Commands.CheckUpdate;
+using DotnetCheckUpdates.Core.Extensions;
+using DotnetCheckUpdates.Core.NuGetUtils;
+using NuGet.Frameworks;
 using Spectre.Console.Testing;
 using static DotnetCheckUpdates.Tests.CheckUpdateCommandUtils;
 using static DotnetCheckUpdates.Tests.Commands.CheckUpdateCommandOutputTests;
+using static DotnetCheckUpdates.Tests.TestUtils;
 
 namespace DotnetCheckUpdates.Tests.Commands;
 
 public class CheckUpdateCommandInteractiveOutputTests
 {
+    [Fact]
+    public async Task InteractiveOutputIncludesConditionContextForDuplicatePackageNames()
+    {
+        var console = new TestConsole().Interactive();
+        var cwd = RootedTestPath("some/path");
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: cwd,
+            fileContents: new()
+            {
+                [cwd.PathCombine("project.csproj")] = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Example" />
+                  </ItemGroup>
+                </Project>
+                """,
+                [cwd.PathCombine(CliConstants.DirectoryPackagesPropsFileName)] = """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageVersion Include="Example" Version="1.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+                    <PackageVersion Include="Example" Version="1.5.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+                  </ItemGroup>
+                </Project>
+                """,
+            }
+        );
+
+        var service = Substitute.For<INuGetService>();
+
+        service
+            .GetPackageVersionsAsync("Example", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(
+                    new[] { "2.0.0".ToNuGetVersion(), "3.0.0".ToNuGetVersion() }.AsEnumerable()
+                )
+            );
+
+        service
+            .GetSupportedFrameworksAsync("Example", "2.0.0", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(ImmutableHashSet.Create(FrameworkConstants.CommonFrameworks.Net80))
+            );
+
+        service
+            .GetSupportedFrameworksAsync("Example", "3.0.0", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(ImmutableHashSet.Create(FrameworkConstants.CommonFrameworks.Net90))
+            );
+
+        var command = CreateCommand(
+            console: console,
+            fileSystem,
+            service,
+            finder: default,
+            solutionFileFormat: SolutionFileFormat.Sln
+        );
+
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var result = await command
+            .AsICommand()
+            .ExecuteAsync(
+                TestCommandContext,
+                new CheckUpdateCommand.Settings
+                {
+                    Cwd = cwd,
+                    Upgrade = true,
+                    AsciiTree = true,
+                    ShowAbsolute = true,
+                    Interactive = true,
+                    HideProgressAfterComplete = true,
+                },
+                CancellationToken.None
+            );
+
+        using var scope = new AssertionScope();
+        result.Should().Be(0);
+
+        var output = console.Output;
+        output.Should().Contain("Example (net8.0) 1.0.0  → 2.0.0");
+        output.Should().Contain("Example (net9.0) 1.5.0  → 3.0.0");
+        output.Should().Contain("Example (net8.0)  1.0.0  →  2.0.0");
+        output.Should().Contain("Example (net9.0)  1.5.0  →  3.0.0");
+    }
+
     [Theory]
     [InlineData("test.sln", SolutionFileFormat.Sln)]
     [InlineData("test.slnx", SolutionFileFormat.Slnx)]

--- a/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandOutputTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandOutputTests.cs
@@ -5,7 +5,9 @@
 using DotnetCheckUpdates.Commands.CheckUpdate;
 using DotnetCheckUpdates.Core;
 using DotnetCheckUpdates.Core.Extensions;
+using DotnetCheckUpdates.Core.NuGetUtils;
 using DotnetCheckUpdates.Core.ProjectModel;
+using NuGet.Frameworks;
 using Spectre.Console.Cli;
 using Spectre.Console.Testing;
 using static DotnetCheckUpdates.Tests.CheckUpdateCommandUtils;
@@ -539,6 +541,276 @@ Projects
 
 Run dotnet-check-updates --cwd {cwd} -u to upgrade
 ";
+        AssertOutput(console, expected);
+    }
+
+    [Fact]
+    public async Task OutputIncludesConditionContextForDuplicatePackageNames()
+    {
+        var cwd = RootedTestPath("some/path");
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: cwd,
+            fileContents: new()
+            {
+                [cwd.PathCombine("project.csproj")] = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Example" />
+                  </ItemGroup>
+                </Project>
+                """,
+                [cwd.PathCombine(CliConstants.DirectoryPackagesPropsFileName)] = """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageVersion Include="Example" Version="1.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+                    <PackageVersion Include="Example" Version="1.5.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+                  </ItemGroup>
+                </Project>
+                """,
+            }
+        );
+
+        var service = Substitute.For<INuGetService>();
+
+        service
+            .GetPackageVersionsAsync("Example", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(
+                    new[] { "2.0.0".ToNuGetVersion(), "3.0.0".ToNuGetVersion() }.AsEnumerable()
+                )
+            );
+
+        service
+            .GetSupportedFrameworksAsync("Example", "2.0.0", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(ImmutableHashSet.Create(FrameworkConstants.CommonFrameworks.Net80))
+            );
+
+        service
+            .GetSupportedFrameworksAsync("Example", "3.0.0", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(ImmutableHashSet.Create(FrameworkConstants.CommonFrameworks.Net90))
+            );
+
+        var console = new TestConsole();
+
+        var command = CreateCommand(
+            console: console,
+            fileSystem,
+            service,
+            finder: default,
+            solutionFileFormat: SolutionFileFormat.Sln
+        );
+
+        var result = await command
+            .AsICommand()
+            .ExecuteAsync(
+                new CommandContext([], Substitute.For<IRemainingArguments>(), "test", null),
+                new CheckUpdateCommand.Settings
+                {
+                    Cwd = cwd,
+                    Upgrade = false,
+                    AsciiTree = true,
+                    ShowAbsolute = true,
+                },
+                CancellationToken.None
+            );
+
+        result.Should().Be(0);
+
+        using var scope = new AssertionScope();
+        console.Output.Should().Contain("Example (net8.0)");
+        console.Output.Should().Contain("Example (net9.0)");
+        console.Output.Should().Contain("1.0.0  →  2.0.0");
+        console.Output.Should().Contain("1.5.0  →  3.0.0");
+
+        var expected =
+            $@"
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+`-- {cwd.PathCombine("project.csproj")}
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+|   `-- Example (net8.0)  1.0.0  →  2.0.0
+|       Example (net9.0)  1.5.0  →  3.0.0
+|
+`-- {cwd.PathCombine("project.csproj")}
+    `-- All packages match their latest versions.
+
+
+Run dotnet-check-updates --cwd {cwd} -u to upgrade
+";
+        AssertOutput(console, expected);
+    }
+
+    [Fact]
+    public async Task OutputIncludesTargetFrameworkAndConditionContext()
+    {
+        var cwd = RootedTestPath("some/path");
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: cwd,
+            fileContents: new()
+            {
+                [cwd.PathCombine("project.csproj")] = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                    <PropertyGroup>
+                        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                    </PropertyGroup>
+
+                    <ItemGroup>
+                        <PackageReference Include="Example" />
+                    </ItemGroup>
+                </Project>
+                """,
+                [cwd.PathCombine(CliConstants.DirectoryPackagesPropsFileName)] = """
+                <Project>
+                    <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                    </PropertyGroup>
+
+                    <ItemGroup>
+                        <PackageVersion Include="Example" Version="1.0.0" Condition="'$(TargetFramework)' == 'net8.0' And '$(TargetFramework)' != 'net9.0'" />
+                    </ItemGroup>
+                </Project>
+                """,
+            }
+        );
+
+        var service = SetupMockNuGetService(BasicMockPackage("Example", "2.0.0"));
+        var console = new TestConsole();
+
+        var command = CreateCommand(
+            console: console,
+            fileSystem,
+            service,
+            finder: default,
+            solutionFileFormat: SolutionFileFormat.Sln
+        );
+
+        var result = await command
+            .AsICommand()
+            .ExecuteAsync(
+                new CommandContext([], Substitute.For<IRemainingArguments>(), "test", null),
+                new CheckUpdateCommand.Settings
+                {
+                    Cwd = cwd,
+                    Upgrade = false,
+                    List = true,
+                    AsciiTree = true,
+                    ShowAbsolute = true,
+                },
+                CancellationToken.None
+            );
+
+        result.Should().Be(0);
+
+        var expected =
+            $@"
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+`-- {cwd.PathCombine("project.csproj")}
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+|   `-- Example (net8.0 And != net9.0)  1.0.0  →  2.0.0
+|
+`-- {cwd.PathCombine("project.csproj")}
+    `-- Example
+
+
+Run dotnet-check-updates --cwd {cwd} -u to upgrade
+";
+
+        AssertOutput(console, expected);
+    }
+
+    [Fact]
+    public async Task OutputIncludesTargetFrameworkOrConditionContext()
+    {
+        var cwd = RootedTestPath("some/path");
+
+        var fileSystem = SetupFileSystem(
+            currentDirectory: cwd,
+            fileContents: new()
+            {
+                [cwd.PathCombine("project.csproj")] = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                    <PropertyGroup>
+                        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                    </PropertyGroup>
+
+                    <ItemGroup>
+                        <PackageReference Include="Example" />
+                    </ItemGroup>
+                </Project>
+                """,
+                [cwd.PathCombine(CliConstants.DirectoryPackagesPropsFileName)] = """
+                <Project>
+                    <PropertyGroup>
+                        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                    </PropertyGroup>
+
+                    <ItemGroup>
+                        <PackageVersion Include="Example" Version="1.0.0" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
+                    </ItemGroup>
+                </Project>
+                """,
+            }
+        );
+
+        var service = SetupMockNuGetService(BasicMockPackage("Example", "2.0.0"));
+        var console = new TestConsole();
+
+        var command = CreateCommand(
+            console: console,
+            fileSystem,
+            service,
+            finder: default,
+            solutionFileFormat: SolutionFileFormat.Sln
+        );
+
+        var result = await command
+            .AsICommand()
+            .ExecuteAsync(
+                new CommandContext([], Substitute.For<IRemainingArguments>(), "test", null),
+                new CheckUpdateCommand.Settings
+                {
+                    Cwd = cwd,
+                    Upgrade = false,
+                    List = true,
+                    AsciiTree = true,
+                    ShowAbsolute = true,
+                },
+                CancellationToken.None
+            );
+
+        result.Should().Be(0);
+
+        var expected =
+            $@"
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+`-- {cwd.PathCombine("project.csproj")}
+Projects
+|-- {cwd.PathCombine("Directory.Packages.props")}
+|   `-- Example (net8.0 Or net9.0)  1.0.0  →  2.0.0
+|
+`-- {cwd.PathCombine("project.csproj")}
+    `-- Example
+
+
+Run dotnet-check-updates --cwd {cwd} -u to upgrade
+";
+
         AssertOutput(console, expected);
     }
 

--- a/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandPackageUpgradeTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Commands/CheckUpdateCommandPackageUpgradeTests.cs
@@ -305,6 +305,79 @@ public class CheckUpdateCommandPackageUpgradeTests
     }
 
     [Fact]
+    public async Task MixedFiltersKeepConditionalDuplicateEntriesWhenPackageNameMatches()
+    {
+        var (cwd, _, fileSystem, command) = SetupCommand(
+            new Dictionary<string, string>
+            {
+                ["project.csproj"] = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageReference Include="Example" />
+                    <PackageReference Include="SkipMe" />
+                  </ItemGroup>
+                </Project>
+                """,
+                [CliConstants.DirectoryPackagesPropsFileName] = """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                  </PropertyGroup>
+
+                  <ItemGroup>
+                    <PackageVersion Include="Example" Version="1.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+                    <PackageVersion Include="Example" Version="1.5.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+                    <PackageVersion Include="SkipMe" Version="4.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+                  </ItemGroup>
+                </Project>
+                """,
+            },
+            new PackageDictionary
+            {
+                ["Example"] = ["2.0.0".ToNuGetVersion()],
+                ["SkipMe"] = ["5.0.0".ToNuGetVersion()],
+            }
+        );
+
+        var result = await command
+            .AsICommand()
+            .ExecuteAsync(
+                TestCommandContext,
+                new CheckUpdateCommand.Settings
+                {
+                    Cwd = cwd,
+                    Upgrade = true,
+                    Target = UpgradeTarget.Latest,
+                    Include = ["Example SkipMe"],
+                    Exclude = ["SkipMe"],
+                },
+                CancellationToken.None
+            );
+
+        result.Should().Be(0);
+
+        var props = await cwd.ReadProjectFile(
+            fileSystem,
+            CliConstants.DirectoryPackagesPropsFileName
+        );
+
+        using var scope = new AssertionScope();
+        props.PackageReferences.Should().HaveCount(3);
+
+        var xml = props.ProjectFileToXml();
+        xml.Should().Contain("Version=\"2.0.0\" Condition=\"'$(TargetFramework)' == 'net8.0'\"");
+        xml.Should().Contain("Version=\"2.0.0\" Condition=\"'$(TargetFramework)' == 'net9.0'\"");
+        xml.Should()
+            .Contain(
+                "<PackageVersion Include=\"SkipMe\" Version=\"4.0.0\" Condition=\"'$(TargetFramework)' == 'net8.0'\" />"
+            );
+    }
+
+    [Fact]
     public async Task UpgradesOnlyPackagesMatchingIncludeFilters()
     {
         // Arrange

--- a/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ParseDirectoryPackagesPropsTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ParseDirectoryPackagesPropsTests.cs
@@ -27,8 +27,9 @@ public class ParseDirectoryPackagesPropsTests
 
         using var scope = new AssertionScope();
         file.TargetFrameworks.Should().BeEmpty();
-        file.PackageReferences.Should()
-            .BeEquivalentTo([new PackageReference("Example", "13.0.1".ToVersionRange())]);
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].Name.Should().Be("Example");
+        file.PackageReferences[0].GetVersionString().Should().Be("13.0.1");
     }
 
     [Fact]
@@ -89,5 +90,290 @@ public class ParseDirectoryPackagesPropsTests
                 </Project>
                 """
             );
+    }
+
+    [Fact]
+    public void CanParseItemAndItemGroupTargetFrameworkConditions()
+    {
+        const string xml = """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+
+              <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+
+              <ItemGroup>
+                <PackageVersion Include="Example2" Version="2.0.0" Condition="'$(TargetFramework)' != 'net9.0'" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().HaveCount(2);
+
+        file.PackageReferences[0].Name.Should().Be("Example");
+        file.PackageReferences[0].TargetFrameworkConditions.Should().ContainSingle();
+        file.PackageReferences[0].DisplayName.Should().Contain("net8.0");
+
+        file.PackageReferences[1].Name.Should().Be("Example2");
+        file.PackageReferences[1].TargetFrameworkConditions.Should().ContainSingle();
+        file.PackageReferences[1].DisplayName.Should().Contain("!= net9.0");
+    }
+
+    [Fact]
+    public void CanParseTargetFrameworkOrCondition()
+    {
+        const string xml = """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+        var package = file.PackageReferences.Should().ContainSingle().Subject;
+
+        package.TargetFrameworkConditions.Should().HaveCount(2);
+        package.DisplayName.Should().Contain("net8.0 Or net9.0");
+        package.TargetFrameworkConditions.Select(it => it.GroupId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CanUpgradeDuplicatePackageNamesWithDifferentConditions()
+    {
+        const string xml = """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+                <PackageVersion Include="Example" Version="14.0.1" Condition="'$(TargetFramework)' == 'net9.0'" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        var first = file.PackageReferences[0];
+        var second = file.PackageReferences[1];
+
+        first.UpgradeKey.Should().NotBe(second.UpgradeKey);
+
+        var result = file.UpdatePackageReferences(
+            new()
+            {
+                [first.UpgradeKey] = "13.1.0".ToVersionRange(),
+                [second.UpgradeKey] = "14.1.0".ToVersionRange(),
+            }
+        );
+
+        result
+            .ProjectFileToXml()
+            .Should()
+            .Contain(
+                "<PackageVersion Include=\"Example\" Version=\"13.1.0\" Condition=\"'$(TargetFramework)' == 'net8.0'\" />"
+            )
+            .And.Contain(
+                "<PackageVersion Include=\"Example\" Version=\"14.1.0\" Condition=\"'$(TargetFramework)' == 'net9.0'\" />"
+            );
+    }
+
+    public static TheoryData<string> ConditionsWithoutSupportedTargetFrameworkPredicate =>
+        new() { "'$(TargetFramework)' &gt;= 'net8.0'", "'$(Configuration)' == 'Release'" };
+
+    [Theory]
+    [MemberData(nameof(ConditionsWithoutSupportedTargetFrameworkPredicate))]
+    public void ConditionWithoutSupportedTargetFrameworkPredicateIsIgnoredWhenAppliedToPackage(
+        string condition
+    )
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="{{condition}}" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].TargetFrameworkConditions.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(ConditionsWithoutSupportedTargetFrameworkPredicate))]
+    public void ConditionWithoutSupportedTargetFrameworkPredicateIsIgnoredWhenAppliedToItemGroupWithPackage(
+        string condition
+    )
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup Condition="{{condition}}">
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].TargetFrameworkConditions.Should().BeEmpty();
+    }
+
+    public static TheoryData<string> MixedConditions =>
+        new()
+        {
+            "'$(TargetFramework)' == 'net8.0' And '$(Configuration)' == 'Release'",
+            "'$(TargetFramework)' != 'net9.0' And '$(UseReproducibleBuild)' == 'true'",
+        };
+
+    [Theory]
+    [MemberData(nameof(MixedConditions))]
+    public void MixedConditionExtractsSupportedTargetFrameworkPredicateFromPackageCondition(
+        string condition
+    )
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="{{condition}}" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].TargetFrameworkConditions.Should().ContainSingle();
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedConditions))]
+    public void MixedConditionExtractsSupportedTargetFrameworkPredicateFromItemGroupCondition(
+        string condition
+    )
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup Condition="{{condition}}">
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].TargetFrameworkConditions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void MixedConditionExtractsMultipleSupportedTargetFrameworkPredicatesInOrder()
+    {
+        const string xml = """
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="'$(TargetFramework)' != 'net8.0' And '$(Configuration)' == 'Release' And '$(TargetFramework)' != 'net9.0'" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0]
+            .TargetFrameworkConditions.Select(it => it.ToDisplayString())
+            .Should()
+            .Equal("!= net8.0", "!= net9.0");
+    }
+
+    [Fact]
+    public void OrConditionAppliesToMatchingFrameworks()
+    {
+        const string xml = """
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var file = ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        file.PackageReferences[0]
+            .GetApplicableFrameworks(file.TargetFrameworks)
+            .Select(it => it.GetShortFolderName())
+            .Should()
+            .Equal("net8.0", "net9.0");
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedConditions))]
+    public void UnsupportedConditionDoesNotThrowWhenAppliedToTarget(string condition)
+    {
+        var xml = $$"""
+            <Project>
+              <Target Condition="{{condition}}"></Target>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var act = () => ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedConditions))]
+    public void UnsupportedConditionDoesNotThrowWhenWhenAppliedToEmptyItemGroup(string condition)
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup Condition="{{condition}}">
+              </ItemGroup>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var act = () => ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(MixedConditions))]
+    public void UnsupportedConditionDoesNotThrowWhenWhenAppliedToItemGroupWithNonPackageElements(
+        string condition
+    )
+    {
+        var xml = $$"""
+            <Project>
+              <ItemGroup Condition="{{condition}}">
+                <Target></Target>
+              </ItemGroup>
+              <ItemGroup>
+                <PackageVersion Include="Example" Version="13.0.1" />
+              </ItemGroup>
+            </Project>
+            """;
+
+        var act = () => ProjectFileParser.ParseLessStrictProjectFile(xml, "test");
+
+        act.Should().NotThrow();
     }
 }

--- a/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ProjectFileParserTests.cs
+++ b/tests/DotnetCheckUpdates.Tests/Core/ProjectModel/ProjectFileParserTests.cs
@@ -388,6 +388,111 @@ public class ProjectFileParserTests
             .WithMessage("Unsupported Project format: TargetFramework(s) are not specified");
     }
 
+    [Fact]
+    public void ParsesCombinedItemGroupAndItemConditions()
+    {
+        var xml = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup Condition=""'$(TargetFramework)' != 'net9.0'"">
+    <PackageReference Include=""Example"" Version=""1.0.0"" Condition=""'$(TargetFramework)' == 'net8.0'"" />
+  </ItemGroup>
+</Project>
+".TrimStart();
+
+        var file = ProjectFileParser.ParseProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+
+        var package = file.PackageReferences[0];
+
+        package.TargetFrameworkConditions.Should().HaveCount(2);
+
+        package
+            .GetApplicableFrameworks(file.TargetFrameworks)
+            .Select(it => it.GetShortFolderName())
+            .Should()
+            .Equal("net8.0");
+    }
+
+    [Fact]
+    public void ParsesOrCondition()
+    {
+        var xml = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Example"" Version=""1.0.0"" Condition=""'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'"" />
+  </ItemGroup>
+</Project>
+".TrimStart();
+
+        var file = ProjectFileParser.ParseProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+
+        var package = file.PackageReferences[0];
+
+        package.TargetFrameworkConditions.Should().HaveCount(2);
+        package
+            .GetApplicableFrameworks(file.TargetFrameworks)
+            .Select(it => it.GetShortFolderName())
+            .Should()
+            .Equal("net8.0", "net9.0");
+    }
+
+    [Fact]
+    public void CombinesItemGroupAndItemOrConditionsUsingAndSemantics()
+    {
+        var xml = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup Condition=""'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'"">
+    <PackageReference Include=""Example"" Version=""1.0.0"" Condition=""'$(TargetFramework)' != 'net9.0' Or '$(TargetFramework)' == 'net10.0'"" />
+  </ItemGroup>
+</Project>
+".TrimStart();
+
+        var file = ProjectFileParser.ParseProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+
+        var package = file.PackageReferences[0];
+
+        package.TargetFrameworkConditions.Should().HaveCount(8);
+        package
+            .GetApplicableFrameworks(file.TargetFrameworks)
+            .Select(it => it.GetShortFolderName())
+            .Should()
+            .Equal("net8.0");
+    }
+
+    [Fact]
+    public void IgnoresUnsupportedItemGroupCondition()
+    {
+        var xml = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup Condition=""'$(Configuration)' == 'Release'"">
+    <PackageReference Include=""Example"" Version=""1.0.0"" />
+  </ItemGroup>
+</Project>
+".TrimStart();
+
+        var file = ProjectFileParser.ParseProjectFile(xml, "test");
+
+        file.PackageReferences.Should().ContainSingle();
+        file.PackageReferences[0].TargetFrameworkConditions.Should().BeEmpty();
+    }
+
     private static string TestProjectFile(IEnumerable<PackageReference>? packages = default) =>
         $@"
 <Project Sdk=""Microsoft.NET.Sdk"">


### PR DESCRIPTION
Packages can be conditioned on `$(TargetFramework)` at either the `<ItemGroup>` level or the individual `<PackageReference>` level, for example:

```xml
<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
  <PackageReference Include="Foo" Version="1.0.0" />
</ItemGroup>

<PackageReference Include="Bar" Version="2.0.0"
    Condition="'$(TargetFramework)' == 'net8.0'
            Or '$(TargetFramework)' == 'net9.0'" />
```

Previously these conditions were ignored, which could cause spurious upgrade suggestions for packages that do not apply to every targeted framework. This change parses those conditions and uses them throughout the upgrade pipeline.

## What changed

### New: `TargetFrameworkCondition`

A small record that captures a single `$(TargetFramework) == 'x'` / `!= 'x'` predicate together with its `GroupId` (used to model `Or` groups) and provides `IsMatch(string)` and `ToDisplayString()`.

### `PackageReference`

- Gains a document-order `ReferenceId` (set by the parser) so that packages with the same name but different conditions can be distinguished.
- Gains `TargetFrameworkConditions` (an `ImmutableArray`) built from both the item-level and item-group-level conditions.
- New helpers: `UpgradeKey` (`"<id>:<name>"` when an id is present, otherwise `"<name>"`), `DisplayName` (appends the grouped conditions in human-readable form), `HasTargetFrameworkConditions`, and `GetApplicableFrameworks(IEnumerable<NuGetFramework>)` which filters the project's target frameworks down to those that satisfy the conditions.

### `ProjectFileParser`

- Added two source-generated regexes to parse condition strings:
  - One for individual `'$(TargetFramework)' == 'x'` / `!= 'x'` predicates.
  - One to split on `Or`.
- `ToPackageReferences()` now threads the element index through as `ReferenceId` and calls the new parsing helpers to populate `TargetFrameworkConditions` from both the item and its parent `<ItemGroup>`.
- When both levels carry conditions they are combined: each item-group group is AND-ed with each item-level group, and the results are OR-ed together.

### `ProjectFile`

- `WithUpgrades` now tries `UpgradeKey` first, falling back to `Name`, so that two references to the same package under different conditions get the right version independently.
- XML writeback prefers index-based (`ReferenceId`) matching when ids are present, avoiding ambiguity for duplicate package names.
- New helpers: `FindByReferenceIdWithIndex` and `FindByIdentityWithIndex`.

### `CheckUpdateCommandHelpers`

- `PackageUpgrade` record expanded with `UpgradeKey`, `PackageName`, and `DisplayName`.
- The upgrade resolution loop keys the result dictionary by `UpgradeKey` instead of bare package name.
- Before fetching the best version, `GetApplicableFrameworks` is called; packages whose conditions exclude all project frameworks are skipped entirely.
- Display (table / interactive) uses `DisplayName` so the user can see which framework condition a package belongs to.

## Tests

- `ProjectFileParserTests`: condition parsing with `==`, `!=`, `Or`, combined item + item-group conditions.
- `ParseDirectoryPackagesPropsTests`: packages with framework conditions in `Directory.Packages.props`.
- `CheckUpdateCommandOutputTests` / `CheckUpdateCommandInteractiveOutputTests`: output format when conditioned packages are present.
- `CheckUpdateCommandPackageUpgradeTests`: upgrade is applied to the correct reference when two packages share a name but differ in condition.
